### PR TITLE
Added Oracle quote groups for string matching.

### DIFF
--- a/Syntaxes/PL SQL (Oracle).tmLanguage
+++ b/Syntaxes/PL SQL (Oracle).tmLanguage
@@ -971,6 +971,14 @@
     </dict>
 		<dict>
 			<key>begin</key>
+			<string>q'\[</string>
+			<key>end</key>
+			<string>\]'</string>
+			<key>name</key>
+			<string>string.group.quote.oracle</string>
+		</dict>
+		<dict>
+			<key>begin</key>
 			<string>'</string>
 			<key>end</key>
 			<string>'</string>


### PR DESCRIPTION
 See http://docs.oracle.com/cd/B28359_01/appdev.111/b28370/literal.htm
Fixes quoted string highlighting in files where strings begin with **q'[** and end with **]'**
